### PR TITLE
Add `anonymousId` query arguments for A/B testing 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.2.0] - 2023-12-05
+
+### Added
+
+- Created query parameter `anonymousId` for `sponsoredProducts` used on A/B testing.
+
 ## [0.1.0] - 2023-10-24
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -59,7 +59,7 @@ type Query {
     """
     dynamicRules: [DynamicRuleInput]
     """
-    Identifier for users, logged or not.
+    Identifier for users, logged in or not. Used for A/B tests.
     """
     anonymousId: String
   ): [SponsoredProduct] @cacheControl(scope: PUBLIC, maxAge: SHORT)

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -58,5 +58,9 @@ type Query {
     Rules for pormoting, demoting, adding or removing products
     """
     dynamicRules: [DynamicRuleInput]
+    """
+    Identifier for users, logged or not.
+    """
+    anonymousId: String
   ): [SponsoredProduct] @cacheControl(scope: PUBLIC, maxAge: SHORT)
 }


### PR DESCRIPTION
#### What problem is this solving?

We need to integrate A/B testing via Osiris. So the ad request must include the argument `anonymousId`.

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

The following query should work:

```graphql
{
  sponsoredProducts(query:"camisa", anonymousId: "the-id") {
    identifier {
      field
      value
    }
  }
}
```

[Test it here](https://orem--biggy.myvtex.com/_v/private/vtex.adserver-graphql@0.1.0/graphiql/v1?query=%7B%0A%20%20sponsoredProducts(query%3A%22camisa%22%2C%20anonymousId%3A%20%22the-id%22)%20%7B%0A%20%20%20%20identifier%20%7B%0A%20%20%20%20%20%20field%0A%20%20%20%20%20%20value%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
