### PR TITLE
feat: add sellerId to SponsoredProduct type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `sellerId` to `SponsoredProduct` type.
+
 ## [0.3.1] - 2024-11-01
 
 ### Added

--- a/graphql/types/SponsoredProduct.graphql
+++ b/graphql/types/SponsoredProduct.graphql
@@ -18,6 +18,11 @@ type SponsoredProduct {
   Sponsored campaign related information should be added here.
   """
   advertisement: Advertisement
+
+  """
+  Seller ID.
+  """
+  sellerId: ID
 }
 
 type ProductUniqueIdentifier {


### PR DESCRIPTION
#### What problem is this solving?

To add the optional field `sellerId` to `SponsoredProduct` type, as now we can have ads from specific sellers as their advertisers. 

This branch was tested on ascm2 dev workspace at biggy account, access the following GraphQL editor and select the adserver build to check it if desired.
[https://ascm2--biggy.myvtex.com/admin/graphql-ide](https://ascm2--biggy.myvtex.com/admin/graphql-ide)

Example:
![image](https://github.com/user-attachments/assets/03ce24af-46a4-410c-8e70-2da021368197)


#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
