### PR TITLE
feat: Add SKU ID to allow segmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Add SKU ID query parameter to segment ads.
+
 ## [0.5.0] - 2025-02-14
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -78,6 +78,10 @@ type Query {
     Maximum number of sponsored products that should be returned.
     """
     sponsoredCount: Int
+    """
+    SKU identifier used to segment the ads.
+    """
+    skuId: String
   ): [SponsoredProduct] @cacheControl(scope: PUBLIC, maxAge: SHORT)
   sponsoredBanners(
     """


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
This PR allows ads segmentation by SKU by adding the SKU ID argument in the query.

#### How should this be manually tested?

Check [#vtex/intelligent-search-api/153](https://github.com/vtex/intelligent-search-api/pull/153).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
